### PR TITLE
Added set_state() method to initialize the entire 64-bit seed.

### DIFF
--- a/include/rlcg.hpp
+++ b/include/rlcg.hpp
@@ -71,6 +71,8 @@ class ReversibleLCG {
     uint64_t x;
 public:
     ReversibleLCG(unsigned int seed) : x(seed){}
+    // Hi 32-bits is the initial value, lo 32-bit is a random seed
+    void seed(uint64_t s) { x = s; }
     unsigned int next() {
         //nextx = (a * x + c) % m;
         x = (A * x + C) & (M - 1);

--- a/include/rlcg.hpp
+++ b/include/rlcg.hpp
@@ -72,7 +72,7 @@ class ReversibleLCG {
 public:
     ReversibleLCG(unsigned int seed) : x(seed){}
     // Hi 32-bits is the initial value, lo 32-bit is a random seed
-    void seed(uint64_t s) { x = s; }
+    void set_state(uint64_t s) { x = s; }
     unsigned int next() {
         //nextx = (a * x + c) % m;
         x = (A * x + C) & (M - 1);


### PR DESCRIPTION
The idea is that the high 32-bit bits can be passed in to guarantee a
known starting value, such that:
    rng.seed(x << 32 | <32-bit-random-seed>);
    assert(x == rng.next().prev());